### PR TITLE
Use tabwidth of 4 for root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,15 @@
         "singleQuote": true,
         "trailingComma": "none",
         "arrowParens": "avoid",
-        "endOfLine": "auto"
+        "endOfLine": "auto",
+        "overrides": [
+            {
+                "files": "package.json",
+                "options": {
+                    "tabWidth": 4
+                }
+            }
+        ]
     },
     "stylelint": {
         "extends": [


### PR DESCRIPTION
The format by hatch does not follow prettier rule